### PR TITLE
make conn keys case insensitive

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `master`
+- connection string keys are case insensitive 
+
 ## `v0.2.3`
 - handle remove trailing slash from host
 

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -70,9 +70,10 @@ func ParsedConnectionFromStr(connStr string) (*ParsedConn, error) {
 		}
 
 		// if a key value pair has `=` in the value, recombine them
+		key := keyAndValue[0]
 		value := strings.Join(keyAndValue[1:], "=")
-		switch keyAndValue[0] {
-		case endpointKey:
+		switch {
+		case strings.EqualFold(endpointKey, key):
 			u, err := url.Parse(value)
 			if err != nil {
 				return nil, errors.New("failed parsing connection string due to an incorrectly formatted Endpoint value")
@@ -83,11 +84,11 @@ func ParsedConnectionFromStr(connStr string) (*ParsedConn, error) {
 			}
 			namespace = hostSplits[0]
 			suffix = strings.Join(hostSplits[1:], ".")
-		case sharedAccessKeyNameKey:
+		case strings.EqualFold(sharedAccessKeyNameKey, key):
 			keyName = value
-		case sharedAccessKeyKey:
+		case strings.EqualFold(sharedAccessKeyKey, key):
 			secret = value
-		case entityPathKey:
+		case strings.EqualFold(entityPathKey, key):
 			hubName = value
 		}
 	}

--- a/conn/conn_test.go
+++ b/conn/conn_test.go
@@ -35,10 +35,21 @@ const (
 	hubName   = "myhub"
 	connStr1  = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";EntityPath=" + hubName
 	connStr2  = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret
+	connStr3  = "endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccesskeyName=" + keyName + ";sharedAccessKey=" + secret + ";Entitypath=" + hubName
 )
 
 func TestParsedConnectionFromStr(t *testing.T) {
 	parsed, err := ParsedConnectionFromStr(connStr1)
+	assert.Nil(t, err)
+	assert.Equal(t, "amqps://"+namespace+".servicebus.windows.net", parsed.Host)
+	assert.Equal(t, namespace, parsed.Namespace)
+	assert.Equal(t, keyName, parsed.KeyName)
+	assert.Equal(t, secret, parsed.Key)
+	assert.Equal(t, hubName, parsed.HubName)
+}
+
+func TestParsedConnectionFromStrCaseIndifference(t *testing.T) {
+	parsed, err := ParsedConnectionFromStr(connStr3)
 	assert.Nil(t, err)
 	assert.Equal(t, "amqps://"+namespace+".servicebus.windows.net", parsed.Host)
 	assert.Equal(t, namespace, parsed.Namespace)


### PR DESCRIPTION
### Fix or Enhancement?
Allow for case insensitive keys in connection strings

- [x] All tests passed
- [x] Add changes to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here