### PR TITLE
lock version for amqp

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,8 +9,8 @@
     "autorest/azure",
     "autorest/date"
   ]
-  revision = "9ad9326b278af8fa5cc67c30c0ce9a58cc0862b2"
-  version = "v10.6.0"
+  revision = "eaa7994b2278094c904d31993d26f56324db3052"
+  version = "v10.8.1"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -59,26 +59,26 @@
     "pkcs12",
     "pkcs12/internal/rc2"
   ]
-  revision = "d6449816ce06963d9d136eee5a56fca5b0616e7e"
+  revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "61147c48b25b599e5b561d2e9c4f3e1ef489ca41"
+  revision = "2491c5de3490fced2f6cff376127c667efeed857"
 
 [[projects]]
-  branch = "master"
   name = "pack.ag/amqp"
   packages = [
     ".",
     "internal/testconn"
   ]
-  revision = "ee6eb7ef6e2355b46a573b0b1799f76259f2ea47"
+  revision = "390d7eaeac0368026b93a13f4f7bc30d903c61cd"
+  version = "v0.5.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6f11b6cba49c265cac76688eba9003e74961def4603f7dfab086f7a996032fd8"
+  inputs-digest = "f9f1060e3c7ee71bbd01a70776552b36abf3ee85145a9961148a76a0da7e3e2f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,4 +4,4 @@
 
 [[constraint]]
     name = "pack.ag/amqp"
-    branch = "master"
+    version = "0.5"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v0.5.0`
+- **Breaking Change** lock dependency to AMQP
+
 ## `v0.4.0`
 - **Breaking Change** remove namespace from SAS provider and return struct rather than interface 
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -2,5 +2,5 @@ package common
 
 const (
 	// Version is the semantic version of the library
-	Version = "0.4.0"
+	Version = "0.5.0"
 )


### PR DESCRIPTION
### Fix or Enhancement?
pin version for amqp - see: https://github.com/Azure/azure-event-hubs-go/issues/35

- [x] All tests passed
- [x] Add changes to `changelog.md`