### PR TITLE
Adding flexibility to "status-code" formatting.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v1.0.2`
+- adding resiliency against malformed "status-code" and "status-description" properties in rpc responses
+
 ## `v1.0.1`
 - bump version constant
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -138,6 +138,8 @@ func (l *Link) RetryableRPC(ctx context.Context, times int, delay time.Duration,
 
 // RPC sends a request and waits on a response for that request
 func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
+	const altStatusCodeKey, altDescriptionKey = "statusCode", "statusDescription"
+
 	l.rpcMu.Lock()
 	defer l.rpcMu.Unlock()
 
@@ -160,7 +162,7 @@ func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
 	}
 
 	var statusCode int
-	statusCodeCandidates := []string{statusCodeKey, "statusCode"}
+	statusCodeCandidates := []string{statusCodeKey, altStatusCodeKey}
 	for i := range statusCodeCandidates {
 		if rawStatusCode, ok := res.ApplicationProperties[statusCodeCandidates[i]]; ok {
 			if cast, ok := rawStatusCode.(int32); ok {
@@ -176,7 +178,7 @@ func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
 	}
 
 	var description string
-	descriptionCandidates := []string{descriptionKey, "statusDescription"}
+	descriptionCandidates := []string{descriptionKey, altDescriptionKey}
 	descriptionFound := false
 	for i := range descriptionCandidates {
 		if rawDescription, ok := res.ApplicationProperties[descriptionCandidates[i]]; ok {


### PR DESCRIPTION
While debugging an unrelated bug in the Service Bus library, I discovered that most Service Bus endpoints will return the values "status-code" and "status-description". However, at least when one sends malformed set-session-state messages, the response will contain "statusCode" and "statusDescription".

### Fix or Enhancement?


- [x] All tests passed
- [x] Add changes to `changelog.md`

### Environment
- OS: darwin/amd64
- Go version: go1.11