### PR TITLE
Updating `golint` package name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(BASE): ; $(info $(M) setting GOPATH…)
 
 GOLINT = $(BIN)/golint
 $(BIN)/golint: | $(BASE) ; $(info $(M) building golint…)
-	$Q go get github.com/golang/lint/golint
+	$Q go get -u golang.org/x/lint/golint
 
 # Tests
 


### PR DESCRIPTION
CI over in #29 is broken because CI fails to install golint. This PR should take care of that.