### PR TITLE
Add server-timeout property to RPC

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v1.1.3`
+- adding automatic server-timeout field for `rpc` package. It gleans the appropriate value from the context passed to it
+
 ## `v1.1.2`
 - adopting go modules 
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -157,6 +157,10 @@ func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
 	}
 	msg.Properties.ReplyTo = l.clientAddress
 
+	if msg.ApplicationProperties == nil {
+		msg.ApplicationProperties = make(map[string]interface{})
+	}
+
 	if _, ok := msg.ApplicationProperties["server-timeout"]; !ok {
 		if deadline, ok := ctx.Deadline(); ok {
 			msg.ApplicationProperties["server-timeout"] = uint(time.Until(deadline) / time.Millisecond)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -157,7 +157,7 @@ func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
 	}
 	msg.Properties.ReplyTo = l.clientAddress
 
-	if msg.ApplicationProperties["server-timeout"] == nil {
+	if _, ok := msg.ApplicationProperties["server-timeout"]; !ok {
 		if deadline, ok := ctx.Deadline(); ok {
 			msg.ApplicationProperties["server-timeout"] = uint(time.Until(deadline) / time.Millisecond)
 		}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -157,6 +157,12 @@ func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
 	}
 	msg.Properties.ReplyTo = l.clientAddress
 
+	if msg.ApplicationProperties["server-timeout"] == nil {
+		if deadline, ok := ctx.Deadline(); ok {
+			msg.ApplicationProperties["server-timeout"] = uint(time.Until(deadline) / time.Millisecond)
+		}
+	}
+
 	err := l.sender.Send(ctx, msg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add `server-timeout` property to RPC whenever context of operation has a deadline set, so that server will stop processing requests where the client is no longer expecting response. 

Signed-off-by: Akhil Mohan <akhilerm@gmail.com>

### Fix or Enhancement?
Fixes #33 

- [x] All tests passed
- [ ] Add changes to `changelog.md`

### Environment
- OS: linux/amd64
- Go version: 1.11