### PR TITLE
softer parsing of status description

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v1.1.4`
+- allow status description on RPC calls to be empty without returning an error https://github.com/Azure/azure-event-hubs-go/issues/88
+
 ## `v1.1.3`
 - adding automatic server-timeout field for `rpc` package. It gleans the appropriate value from the context passed to it
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -2,5 +2,5 @@ package common
 
 const (
 	// Version is the semantic version of the library
-	Version = "1.0.1"
+	Version = "1.1.4"
 )

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -195,10 +195,8 @@ func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
 
 	var description string
 	descriptionCandidates := []string{descriptionKey, altDescriptionKey}
-	descriptionFound := false
 	for i := range descriptionCandidates {
 		if rawDescription, ok := res.ApplicationProperties[descriptionCandidates[i]]; ok {
-			descriptionFound = true
 			if description, ok = rawDescription.(string); ok || rawDescription == nil {
 				break
 			} else {
@@ -206,12 +204,8 @@ func (l *Link) RPC(ctx context.Context, msg *amqp.Message) (*Response, error) {
 			}
 		}
 	}
-	if !descriptionFound {
-		return nil, errors.New("status description was not found on rpc message")
-	}
 
 	res.Accept()
-
 	return &Response{
 		Code:        int(statusCode),
 		Description: description,


### PR DESCRIPTION
### Fix or Enhancement?
Fix for softer status description parsing

- [x] All tests passed
- [x] Add changes to `changelog.md`

resolves https://github.com/Azure/azure-event-hubs-go/issues/88