### PR TITLE
option to pass managed identity client id to AD authentication

### DIFF
--- a/aad/jwt.go
+++ b/aad/jwt.go
@@ -188,7 +188,7 @@ func (c *TokenProviderConfiguration) NewServicePrincipalToken() (*adal.ServicePr
 	if err != nil {
 		return nil, err
 	}
-	spToken, err := c.getTokenProvider(msiEndpoint)
+	spToken, err := c.getMSIToken(msiEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get oauth token from MSI: %v", err)
 	}
@@ -198,7 +198,7 @@ func (c *TokenProviderConfiguration) NewServicePrincipalToken() (*adal.ServicePr
 	return spToken, nil
 }
 
-func (c *TokenProviderConfiguration) getTokenProvider(msiEndpoint string) (*adal.ServicePrincipalToken, error) {
+func (c *TokenProviderConfiguration) getMSIToken(msiEndpoint string) (*adal.ServicePrincipalToken, error) {
 	if c.ClientID == "" {
 		return adal.NewServicePrincipalTokenFromMSI(msiEndpoint, c.ResourceURI)
 	}

--- a/aad/jwt.go
+++ b/aad/jwt.go
@@ -197,12 +197,14 @@ func (c *TokenProviderConfiguration) NewServicePrincipalToken() (*adal.ServicePr
 	}
 	return spToken, nil
 }
-func (c *TokenProviderConfiguration) getTokenProvider(msiEndpoint string) (*adal.ServicePrincipalToken, error){
+
+func (c *TokenProviderConfiguration) getTokenProvider(msiEndpoint string) (*adal.ServicePrincipalToken, error) {
 	if c.ClientID == "" {
 		return adal.NewServicePrincipalTokenFromMSI(msiEndpoint, c.ResourceURI)
 	}
 	return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, c.ResourceURI, c.ClientID)
 }
+
 // GetToken gets a CBS JWT
 func (t *TokenProvider) GetToken(audience string) (*auth.Token, error) {
 	token := t.tokenProvider.Token()

--- a/aad/jwt.go
+++ b/aad/jwt.go
@@ -200,9 +200,8 @@ func (c *TokenProviderConfiguration) NewServicePrincipalToken() (*adal.ServicePr
 func (c *TokenProviderConfiguration) getTokenProvider(msiEndpoint string) (*adal.ServicePrincipalToken, error){
 	if c.ClientID == "" {
 		return adal.NewServicePrincipalTokenFromMSI(msiEndpoint, c.ResourceURI)
-	} else {
-		return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, c.ResourceURI, c.ClientID)
 	}
+	return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, c.ResourceURI, c.ClientID)
 }
 // GetToken gets a CBS JWT
 func (t *TokenProvider) GetToken(audience string) (*auth.Token, error) {

--- a/aad/jwt.go
+++ b/aad/jwt.go
@@ -188,7 +188,7 @@ func (c *TokenProviderConfiguration) NewServicePrincipalToken() (*adal.ServicePr
 	if err != nil {
 		return nil, err
 	}
-	spToken, err := adal.NewServicePrincipalTokenFromMSI(msiEndpoint, c.ResourceURI)
+	spToken, err := c.getTokenProvider(msiEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get oauth token from MSI: %v", err)
 	}
@@ -197,7 +197,13 @@ func (c *TokenProviderConfiguration) NewServicePrincipalToken() (*adal.ServicePr
 	}
 	return spToken, nil
 }
-
+func (c *TokenProviderConfiguration) getTokenProvider(msiEndpoint string) (*adal.ServicePrincipalToken, error){
+	if c.ClientID == "" {
+		return adal.NewServicePrincipalTokenFromMSI(msiEndpoint, c.ResourceURI)
+	} else {
+		return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, c.ResourceURI, c.ClientID)
+	}
+}
 // GetToken gets a CBS JWT
 func (t *TokenProvider) GetToken(audience string) (*auth.Token, error) {
 	token := t.tokenProvider.Token()


### PR DESCRIPTION
… managed identity to be used for MSI authentication

### Fix or Enhancement?
https://github.com/Azure/azure-amqp-common-go/issues/44

- [x] All tests passed
- [ ] Add changes to `changelog.md`

### Environment
- OS: Write here
- Go version: 3.x