### PR TITLE
return the error when refresh fails, not the token

### DIFF
--- a/aad/jwt.go
+++ b/aad/jwt.go
@@ -178,7 +178,7 @@ func (c *TokenProviderConfiguration) NewServicePrincipalToken() (*adal.ServicePr
 			return nil, fmt.Errorf("failed to get oauth token from certificate auth: %v", err)
 		}
 		if err := spToken.Refresh(); err != nil {
-			return nil, fmt.Errorf("failed to refersh token: %v", spToken)
+			return nil, fmt.Errorf("failed to refresh token: %v", err)
 		}
 		return spToken, nil
 	}

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## `head`
+- fix refresh error to return the underlying http error instead of the token
 
 ## `v2.1.1`
 - bump amqp to v0.12.1


### PR DESCRIPTION
### Fix 
This fixes the error message returned when refreshing the token fails.
it currently returns the token : 

```
failed to refersh token: &{{{ 0 0 0 } 0xcb74e8 {{ <nil> false } { <nil> false } {http <nil> 169.254.169.254 /metadata/identity
/oauth2/token false api-version=2018-02-01&client_id=XXXXX&resource=https%3A%2F%2Fservicebus.azure.net%2F } { 
<nil> false }} XXXXXXXXX https://servicebus.azure.net/ true 300000000000} 0xc0000cf800 0xc00017f740 <nil> [] 5}
```

changing it to return the actual error provides the right information: 

```
 Error: Received unexpected error:
failed to refresh token: the MSI endpoint is not available. Failed HTTP request to MSI endpoint:
Get "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01": context deadline exceeded
```

Which in my case was a the IMDS endpoint timing out.
This happens very easily when running a set of integration tests concurrently (just a dozen...), each authenticating to the IMDS endpoint.
It seems that IMDS handles them very badly.

- [x] All tests passed
- [x] Add changes to `changelog.md`

### Environment
- OS: Darwin Kernel Version 19.6.0
- Go version: 1.14