### PR TITLE
Change the default credits for the RPC link to be more reasonable (1000)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## `v3.1.2`
 - Change the default credits for the RPC link to be more reasonable (1000)
-  [PR#TBD]()
+  [PR#54](https://github.com/Azure/azure-amqp-common-go/pull/54)
 
 ## `v3.1.1`
 - Change `Link` so it can handle parallel requests. 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## `v3.1.2`
+- Change the default credits for the RPC link to be more reasonable (1000)
+  [PR#TBD]()
+
 ## `v3.1.1`
 - Change `Link` so it can handle parallel requests. 
   [PR#52](https://github.com/Azure/azure-amqp-common-go/pull/52)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -40,9 +40,10 @@ import (
 )
 
 const (
-	replyPostfix   = "-reply-to-"
-	statusCodeKey  = "status-code"
-	descriptionKey = "status-description"
+	replyPostfix           = "-reply-to-"
+	statusCodeKey          = "status-code"
+	descriptionKey         = "status-description"
+	defaultReceiverCredits = 1000
 )
 
 type (
@@ -148,6 +149,7 @@ func NewLinkWithSession(session *amqp.Session, address string, opts ...LinkOptio
 	receiverOpts := []amqp.LinkOption{
 		amqp.LinkSourceAddress(address),
 		amqp.LinkTargetAddress(link.clientAddress),
+		amqp.LinkCredit(defaultReceiverCredits),
 	}
 
 	if link.sessionID != nil {


### PR DESCRIPTION
Use a higher link credit count by default for the rpc link (it's defaulting to 1 today)
    
In the future we could control this manually since we know when responses are expected. This should be fine in the meantime.