### PR TITLE
Sleep before retrying on a transient error

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -227,6 +227,9 @@ func (l *Link) startResponseRouter() {
 		if isClosedError(err) {
 			l.broadcastError(err)
 			break
+		} else if err != nil {
+			// this is some transient error, sleep before trying again
+			time.Sleep(time.Second)
 		}
 
 		// I don't believe this should happen. The JS version of this same code


### PR DESCRIPTION
To avoid excessive CPU consumption.

NOTE: this is a stop the bleeding fix until we can come up with a proper solution to recover the RPC link (hopefully we can jettison this code for track 2).