### PR TITLE
Fix build with Go 1.24

### DIFF
--- a/sas/sas_test.go
+++ b/sas/sas_test.go
@@ -64,7 +64,7 @@ func parseSig(sigStr string) (*sig, error) {
 		case "skn":
 			parsed.skn = keyValue[1]
 		default:
-			return nil, fmt.Errorf(fmt.Sprintf("unknown key / value: %q", keyValue))
+			return nil, fmt.Errorf("unknown key / value: %q", keyValue)
 		}
 	}
 	return parsed, nil


### PR DESCRIPTION
Go 1.24 provides stricter checking that forbids passing a variable as a format string to Printf-like functions with no other arguments. Remove instances of this. See also:

https://tip.golang.org/doc/go1.24#vet

### Fix or Enhancement?
Fix

- All tests passed
- This is a minor change with no release, so I did not modify changelog.md.

### Environment
- OS: Linux
- Go 1.24